### PR TITLE
Add support for f16

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+The pointer-sized floating-point type.
+
+The size of this primitive is how many bytes it takes to reference any location in memory. For example, on a 32 bit target, this is 4 bytes and on a 64 bit target, this is 8 bytes.
+
+As there is no f8 type, 8 bit systems are not supported.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //! The pointer-sized floating-point type.
 //! 
 //! The size of this primitive is how many bytes it takes to reference any location in memory. For example, on a 32 bit target, this is 4 bytes and on a 64 bit target, this is 8 bytes.
-//! As f8 does not exist 
+//! As f8 does not exist and #[cfg] cannot check for 128 bit systems, only 8, 16 and 32 bits are supported.
 
 #[cfg(target_pointer_width = "16")]
 pub type fsize = f16;
@@ -15,8 +15,5 @@ pub type fsize = f32;
 #[cfg(target_pointer_width = "64")]
 pub type fsize = f64;
 
-#[cfg(target_pointer_width = "128")]
-pub type fsize = f128;
-
-#[cfg(target_pointer_width = "8")]
-compile_error!("8-bit systems are not supported.");
+#[cfg(not(any(target_pointer_width = "16", target_pointer_width = "32", target_pointer_width="64")))]
+compile_error!("Only 16, 32 and 64 bit systems support fsize.");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![allow(non_camel_case_types)]
+#![feature(f16)]
 
 //! The pointer-sized floating-point type.
 //! 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,8 +4,10 @@
 //! The pointer-sized floating-point type.
 //! 
 //! The size of this primitive is how many bytes it takes to reference any location in memory. For example, on a 32 bit target, this is 4 bytes and on a 64 bit target, this is 8 bytes.
-//!
-//! As Rust only supports [`f32`](https://doc.rust-lang.org/std/primitive.f32.html) and  [`f64`](https://doc.rust-lang.org/std/primitive.f64.html), `fsize` is only provided for 32 and 64 bit targets.
+//! As f8 does not exist 
+
+#[cfg(target_pointer_width = "16")]
+pub type fsize = f16;
 
 #[cfg(target_pointer_width = "32")]
 pub type fsize = f32;
@@ -13,5 +15,8 @@ pub type fsize = f32;
 #[cfg(target_pointer_width = "64")]
 pub type fsize = f64;
 
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
-compile_error!("Unsupported target pointer width");
+#[cfg(target_pointer_width = "128")]
+pub type fsize = f128;
+
+#[cfg(target_pointer_width = "8")]
+compile_error!("8-bit systems are not supported.");


### PR DESCRIPTION
You write in docs.rs: "As Rust only supports [f32](https://doc.rust-lang.org/std/primitive.f32.html) and [f64](https://doc.rust-lang.org/std/primitive.f64.html), fsize is only provided for 32 and 64 bit targets." However, `f16` and `f128` do exist (though nightly). However, as `#cfg` cannot see 128 bit systems, I have excluded `f128` 